### PR TITLE
Bone and fat butchery change

### DIFF
--- a/Source/ButcherProperties.cs
+++ b/Source/ButcherProperties.cs
@@ -1,0 +1,17 @@
+﻿using Verse;
+using RimWorld;
+
+namespace DankPyon
+{
+    class ButcherProperties : DefModExtension
+    {
+        public bool hasBone = true;
+
+        public bool hasFat = true;
+
+        public static ButcherProperties Get(Def def)
+        {
+            return def.GetModExtension<ButcherProperties>();
+        }
+    }
+}

--- a/Source/HarmonyInstance.cs
+++ b/Source/HarmonyInstance.cs
@@ -209,13 +209,32 @@ namespace DankPyon
         {
             if (__instance is Pawn pawn && pawn.RaceProps.IsFlesh && pawn.RaceProps.meatDef != null)
             {
-                Thing Bone = ThingMaker.MakeThing(bone, null);
-                Thing Fat = ThingMaker.MakeThing(fat, null);
-                int amount = Math.Max(1, (int)(GenMath.RoundRandom(__instance.GetStatValue(StatDefOf.MeatAmount, true) * efficiency) * 0.2f));
-                Bone.stackCount = amount;
-                Fat.stackCount = amount;
-                __result = __result.AddItem(Bone);
-                __result = __result.AddItem(Fat);
+                bool boneFlag = true;
+                bool fatFlag = true;
+
+                var butcherProperties = ButcherProperties.Get(__instance.def);
+                if (butcherProperties != null)
+                {
+                    boneFlag = butcherProperties.hasBone;
+                    fatFlag = butcherProperties.hasFat;
+                }
+
+                if (boneFlag || fatFlag)
+                {
+                    int amount = Math.Max(1, (int)(GenMath.RoundRandom(__instance.GetStatValue(StatDefOf.MeatAmount, true) * efficiency) * 0.2f));
+                    if (boneFlag)
+                    {
+                        Thing Bone = ThingMaker.MakeThing(bone, null);
+                        Bone.stackCount = amount;
+                        __result = __result.AddItem(Bone);
+                    }
+                    if (fatFlag)
+                    {
+                        Thing Fat = ThingMaker.MakeThing(fat, null);
+                        Fat.stackCount = amount;
+                        __result = __result.AddItem(Fat);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Now checks for the ModExtension "DankPyon_MedievalOverhaul.ButcherProperties", which allows animals to not give fat and/or bone when butchered. If the mod extension isn't present then the Harmony patch just executes as normal.