### PR TITLE
Minor Bugfixes

### DIFF
--- a/1.3/Defs/ThingDefs_Buildings/Buildings_Art.xml
+++ b/1.3/Defs/ThingDefs_Buildings/Buildings_Art.xml
@@ -264,7 +264,7 @@
     </placeWorkers>
     <drawPlaceWorkersWhileSelected>true</drawPlaceWorkersWhileSelected>
 
-    <comps>
+    <comps Inherit="False">
       <li Class="CompProperties_Styleable" />
       <li Class="CompProperties_Glower">
         <glowRadius>18</glowRadius>
@@ -304,6 +304,15 @@
           </li>
         </offsets>
       </li>
+	  <!-- SculptureBase comps -->
+	  <li>
+		<compClass>CompQuality</compClass>
+	  </li>
+	  <li Class="CompProperties_Art">
+		<nameMaker>NamerArtSculpture</nameMaker>
+		<descriptionMaker>ArtDescription_Sculpture</descriptionMaker>
+		<canBeEnjoyedAsArt>true</canBeEnjoyedAsArt>
+	  </li>
     </comps>
 </ThingDef>
 
@@ -345,8 +354,8 @@
     </placeWorkers>
     <drawPlaceWorkersWhileSelected>true</drawPlaceWorkersWhileSelected>
 
-    <comps>
-      <li Class="CompProperties_Styleable" />
+    <comps Inherit="False">
+      <li Class="CompProperties_Styleable" /> <!-- Duplicate -->
       <li Class="CompProperties_Glower">
         <glowRadius>10</glowRadius>
         <glowColor>(252,187,113,0)</glowColor>
@@ -360,7 +369,7 @@
         <fireSize>0.8</fireSize>
         <offset>(0,0,0.6)</offset>
       </li>
-      <li Class="CompProperties_MeditationFocus">
+      <li Class="CompProperties_MeditationFocus"> <!-- Duplicate -->
         <statDef>MeditationFocusStrength</statDef>
         <focusTypes><li>Flame</li></focusTypes>
         <offsets>
@@ -385,6 +394,15 @@
           </li>
         </offsets>
       </li>
+	  <!-- SculptureBase comps -->
+	  <li>
+		<compClass>CompQuality</compClass>
+	  </li>
+	  <li Class="CompProperties_Art">
+		<nameMaker>NamerArtSculpture</nameMaker>
+		<descriptionMaker>ArtDescription_Sculpture</descriptionMaker>
+		<canBeEnjoyedAsArt>true</canBeEnjoyedAsArt>
+	  </li>
     </comps>
 </ThingDef>
   

--- a/1.3/Defs/ThingDefs_Buildings/Buildings_Furniture.xml
+++ b/1.3/Defs/ThingDefs_Buildings/Buildings_Furniture.xml
@@ -25,9 +25,9 @@
     <statBases>
       <StyleDominance MayRequire="Ludeon.RimWorld.Ideology">5</StyleDominance>
     </statBases>
-    <comps>
+    <!--comps>
       <li Class="CompProperties_Styleable" Inherit="False"/>
-    </comps>
+    </comps-->
   </ThingDef>
 
   <ThingDef Abstract="True" ParentName="TableBase" Name="DankPyon_TableBase">
@@ -1078,13 +1078,14 @@
     </building>
     <inspectorTabs>
       <li>ITab_Storage</li>
+	  <li>LWM.DeepStorage.ITab_DeepStorage_Inventory</li>
     </inspectorTabs>
     <designationHotKey>Misc12</designationHotKey>
 	<designationCategory>DankPyon_RusticFurniture</designationCategory>
     <staticSunShadowHeight>0.5</staticSunShadowHeight>
     <surfaceType>Item</surfaceType>
     <canOverlapZones>false</canOverlapZones>
-	    <comps>
+	<comps>
       <li Class="CompProperties_Facility">
         <statOffsets>
           <Comfort>0.05</Comfort>
@@ -1092,6 +1093,13 @@
         <maxSimultaneous>1</maxSimultaneous>
         <maxDistance>6</maxDistance>
       </li>
+	  <li Class="LWM.DeepStorage.Properties">
+		<minNumberStacks>1</minNumberStacks>
+		<maxNumberStacks>5</maxNumberStacks>
+		<timeStoringTakes>80</timeStoringTakes>
+		<showContents>false</showContents>
+		<overlayType>None</overlayType>
+	  </li>
     </comps>
   </ThingDef>
   
@@ -1195,6 +1203,7 @@
     </building>
     <inspectorTabs>
       <li>ITab_Storage</li>
+	  <li>LWM.DeepStorage.ITab_DeepStorage_Inventory</li>
     </inspectorTabs>
     <designationHotKey>Misc12</designationHotKey>
     <staticSunShadowHeight>0.5</staticSunShadowHeight>
@@ -1209,6 +1218,13 @@
         <maxSimultaneous>1</maxSimultaneous>
         <maxDistance>6</maxDistance>
       </li>
+	  <li Class="LWM.DeepStorage.Properties">
+		<minNumberStacks>1</minNumberStacks>
+		<maxNumberStacks>5</maxNumberStacks>
+		<timeStoringTakes>60</timeStoringTakes>
+		<showContents>false</showContents>
+		<overlayType>None</overlayType>
+	  </li>
   </comps>
   <constructionSkillPrerequisite>6</constructionSkillPrerequisite>
   </ThingDef>

--- a/1.3/Defs/ThingDefs_Plants/Plants_Wild_DarkForest.xml
+++ b/1.3/Defs/ThingDefs_Plants/Plants_Wild_DarkForest.xml
@@ -13,7 +13,7 @@
 				<offset>(0,0,-0.25)</offset>
 			</shadowData>
 		</graphicData>
-		<altitudeLayer>Skyfaller</altitudeLayer>
+		<altitudeLayer>Pawn</altitudeLayer>
 		<statBases>
 			<Beauty>15</Beauty>
 			<MaxHitPoints>400</MaxHitPoints>
@@ -23,7 +23,7 @@
 		<plant>
 			<dieIfLeafless>False</dieIfLeafless> 
 			<fertilityMin>0.8</fertilityMin>
-			<harvestedThingDef>DankPyon_DarkWoodLog</harvestedThingDef>
+			<harvestedThingDef>DankPyon_RawDarkWood</harvestedThingDef>
 			<fertilitySensitivity>0.8</fertilitySensitivity>
 			<leaflessGraphicPath>Plants_Leafless/GreatOak_Leafless</leaflessGraphicPath>
 			<growDays>300</growDays>
@@ -43,7 +43,7 @@
 				<mentalStateDef>Manhunter</mentalStateDef>
 				<numberToSpawn>1~1</numberToSpawn>
 				<letterLabel>Angry Schrat</letterLabel>
-				<letterDescription>An ancient shcrat has been angered due to the cutting of trees. Prepare yourself!</letterDescription>
+				<letterDescription>An ancient schrat has been angered due to the cutting of trees. Prepare yourself!</letterDescription>
 				<letterDef>ThreatBig</letterDef>
 				<notToxicFallout>false</notToxicFallout>
 			</li>
@@ -92,7 +92,7 @@
 		<plant>
 			<dieIfLeafless>False</dieIfLeafless> 
 			<fertilityMin>0.8</fertilityMin>
-			<harvestedThingDef>DankPyon_DarkWoodLog</harvestedThingDef>
+			<harvestedThingDef>DankPyon_RawDarkWood</harvestedThingDef>
 			<fertilitySensitivity>0.8</fertilitySensitivity>
 			<leaflessGraphicPath>Plants_Leafless/GreatIter_Leafless</leaflessGraphicPath>
 			<growDays>300</growDays>
@@ -112,7 +112,7 @@
 				<mentalStateDef>Manhunter</mentalStateDef>
 				<numberToSpawn>1~1</numberToSpawn>
 				<letterLabel>Angry Schrat</letterLabel>
-				<letterDescription>An ancient shcrat has been angered due to the cutting of trees. Prepare yourself!</letterDescription>
+				<letterDescription>An ancient schrat has been angered due to the cutting of trees. Prepare yourself!</letterDescription>
 				<letterDef>ThreatBig</letterDef>
 				<notToxicFallout>false</notToxicFallout>
 			</li>
@@ -156,6 +156,7 @@
 		<plant>
 			<dieIfLeafless>False</dieIfLeafless> 
 			<fertilityMin>0.4</fertilityMin>
+			<harvestedThingDef>DankPyon_RawDarkWood</harvestedThingDef>
 			<growDays>18</growDays>
 			<harvestWork>2000</harvestWork>
 			<harvestYield>150</harvestYield>
@@ -225,7 +226,7 @@
 			<mentalStateDef>Manhunter</mentalStateDef>
 			<numberToSpawn>1~1</numberToSpawn>
 			<letterLabel>Angry Schrat</letterLabel>
-			<letterDescription>An ancient shcrat has been angered due to the cutting of trees. Prepare yourself!</letterDescription>
+			<letterDescription>An ancient schrat has been angered due to the cutting of trees. Prepare yourself!</letterDescription>
 			<letterDef>ThreatBig</letterDef>
 			<notToxicFallout>false</notToxicFallout>
 		</li>


### PR DESCRIPTION
Buildings_Furniture
*) Added LWM to RusticChest.
*) Added LWM to RoyalChest.
*) DankPyon_TableGatherSpotBase: Removed CompProperties_Styleable from comps. As the comp already exists in the TableGatherSpotBase, which caused an error when loading a savegame.

Buildings_Art
*) DankPyon_Brazier1x1c: comps no longer inherits stuff from the parent's parent SculptureBase. As this caused some errors while loading a savegame, because of some duplicates. Therefore I've added the SculptureBase's compClass and CompProperties_Art to the Brazier.
*) DankPyon_Brazier2x2c: comps no longer inherits stuff from the parent's parent SculptureBase. As this caused some errors while loading a savegame, because of some duplicates. Therefore I've added the SculptureBase's compClass and CompProperties_Art to the Brazier.

Plants_Wild_DarkForest
*) Fixed the typo "shcrat" in comps/MedievalOverhaul.CompProperties_PawnSpawnerOnDestroy/letterDescription for every greater tree.
*) DankPyon_GreatOak: Changed plant/harvestedThingDef from DankPyon_DarkWoodLog to DankPyon_RawDarkWood
*) DankPyon_GreatOak: Set altitudeLayer to pawn
*) DankPyon_GreatIter: Changed plant/harvestedThingDef from DankPyon_DarkWoodLog to DankPyon_RawDarkWood
*) DankPyon_GreatFir: Added plant/harvestedThingDef DankPyon_RawDarkWood