### PR TITLE
VFE:Tribals integration and patches

### DIFF
--- a/1.4/Patches/Add_AffectedByFacilities_SimpleResearchBench.xml
+++ b/1.4/Patches/Add_AffectedByFacilities_SimpleResearchBench.xml
@@ -1,34 +1,59 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName = "SimpleResearchBench"]</xpath>
-		<value>
-			<comps>
-				<li Class="CompProperties_AffectedByFacilities">
-				  <linkableFacilities>
-					<li>DankPyon_RusticBookshelf</li>
-          			<li>DankPyon_Book_MilitaryBlades</li>
-					<li>DankPyon_Book_NobleBlades</li>
-					<li>DankPyon_Book_MilitaryMaces</li>
-					<li>DankPyon_Book_NobleMaces</li>
-					<li>DankPyon_Book_MilitaryPolearms</li>
-					<li>DankPyon_Book_NoblePolearms</li>
-					<li>DankPyon_Book_Crossbow</li>
-					<li>DankPyon_Book_HeavyCrossbow</li>
-					<li>DankPyon_Book_Steel</li>
-					<li>DankPyon_Book_Gunpowder</li>
-					<li>DankPyon_Book_Tar</li>
-					<li>DankPyon_Book_GreatBow</li>
-					<li>DankPyon_Book_WarBow</li>
-					<li>DankPyon_Book_IntermediateCooking</li>
-					<li>DankPyon_Book_AdvancedCooking</li>
-					<li>DankPyon_Book_BallistaRepeater</li>
-				  </linkableFacilities>
-				</li>
-			</comps>
-		</value>
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="SimpleResearchBench"]/comps/li[@Class="CompProperties_AffectedByFacilities"]/linkableFacilities</xpath>
+
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="SimpleResearchBench"]/comps/li[@Class="CompProperties_AffectedByFacilities"]/linkableFacilities</xpath>
+			<value>
+				<li>DankPyon_RusticBookshelf</li>
+				<li>DankPyon_Book_MilitaryBlades</li>
+				<li>DankPyon_Book_NobleBlades</li>
+				<li>DankPyon_Book_MilitaryMaces</li>
+				<li>DankPyon_Book_NobleMaces</li>
+				<li>DankPyon_Book_MilitaryPolearms</li>
+				<li>DankPyon_Book_NoblePolearms</li>
+				<li>DankPyon_Book_Crossbow</li>
+				<li>DankPyon_Book_HeavyCrossbow</li>
+				<li>DankPyon_Book_Steel</li>
+				<li>DankPyon_Book_Gunpowder</li>
+				<li>DankPyon_Book_Tar</li>
+				<li>DankPyon_Book_GreatBow</li>
+				<li>DankPyon_Book_WarBow</li>
+				<li>DankPyon_Book_IntermediateCooking</li>
+				<li>DankPyon_Book_AdvancedCooking</li>
+				<li>DankPyon_Book_BallistaRepeater</li>
+			</value>
+		</match>
+
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="SimpleResearchBench"]</xpath>
+			<value>
+				<comps>
+					<li Class="CompProperties_AffectedByFacilities">
+					  <linkableFacilities>
+						<li>DankPyon_RusticBookshelf</li>
+						<li>DankPyon_Book_MilitaryBlades</li>
+						<li>DankPyon_Book_NobleBlades</li>
+						<li>DankPyon_Book_MilitaryMaces</li>
+						<li>DankPyon_Book_NobleMaces</li>
+						<li>DankPyon_Book_MilitaryPolearms</li>
+						<li>DankPyon_Book_NoblePolearms</li>
+						<li>DankPyon_Book_Crossbow</li>
+						<li>DankPyon_Book_HeavyCrossbow</li>
+						<li>DankPyon_Book_Steel</li>
+						<li>DankPyon_Book_Gunpowder</li>
+						<li>DankPyon_Book_Tar</li>
+						<li>DankPyon_Book_GreatBow</li>
+						<li>DankPyon_Book_WarBow</li>
+						<li>DankPyon_Book_IntermediateCooking</li>
+						<li>DankPyon_Book_AdvancedCooking</li>
+						<li>DankPyon_Book_BallistaRepeater</li>
+					  </linkableFacilities>
+					</li>
+				</comps>
+			</value>
+		</nomatch>
 	</Operation>
-
-
 </Patch>

--- a/1.4/Patches/Change_Research.xml
+++ b/1.4/Patches/Change_Research.xml
@@ -92,32 +92,33 @@
 		</match>
 	</Operation>
 
-	
-	
+
+
 	<!-- ============================ Core Research Project Removal ========================== -->
-	
+
 	<!-- ============================ Tweaked by pre-existing patches ========================== -->
 	<!-- defName="Brewing" or -->
 	<!-- defName="RecurveBow" or -->
 	<!-- defName="Greatbow" or -->
 	<!-- defName="PlateArmor" or -->
 	<!-- ============================ Core Research Project Prerequisite Add ========================== -->
-	<Operation Class="PatchOperationAdd">
-		<xpath>/Defs/ResearchProjectDef[defName="Smithing"]</xpath>
-		<value>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ResearchProjectDef[defName="Smithing" or defName="Brewing" or defName="ComplexFurniture"]/prerequisites</xpath>
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/ResearchProjectDef[defName="Smithing" or defName="Brewing" or defName="ComplexFurniture"]/prerequisites</xpath>
+			<value>
+				<li>DankPyon_RusticFurniture</li>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ResearchProjectDef[defName="Smithing" or defName="Brewing" or defName="ComplexFurniture"]</xpath>
+			<value>
 				<prerequisites>
 					<li>DankPyon_RusticFurniture</li>
 				</prerequisites>
-		</value>
-	</Operation>
-	
-	<Operation Class="PatchOperationAdd">
-		<xpath>/Defs/ResearchProjectDef[defName="Brewing"]</xpath>
-		<value>
-				<prerequisites>
-					<li>DankPyon_RusticFurniture</li>
-				</prerequisites>
-		</value>
+			</value>
+		</nomatch>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
@@ -127,24 +128,6 @@
 				<li>DankPyon_TextileSpinning</li>
 			</prerequisites>
 		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ResearchProjectDef[defName = "ComplexFurniture"]/prerequisites</xpath>
-		<match Class="PatchOperationAdd">
-			<xpath>Defs/ResearchProjectDef[defName = "ComplexFurniture"]/prerequisites</xpath>
-			<value>
-				<li>DankPyon_RusticFurniture</li>
-			</value>
-		</match>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/ResearchProjectDef[defName = "ComplexFurniture"]</xpath>
-			<value>
-				<prerequisites>
-					<li>DankPyon_RusticFurniture</li>
-				</prerequisites>
-			</value>
-		</nomatch>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
@@ -391,7 +374,7 @@
 			</recipeMaker>
 		</value>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="MeleeWeapon_Spear"]/recipeMaker/researchPrerequisite</xpath>
 		<value>
@@ -406,24 +389,42 @@
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="TableSculpting" or defName="FueledStove" or defName="TableButcher"]</xpath>
-		<value>
-			<researchPrerequisites>
-				<li>ComplexFurniture</li>
-			</researchPrerequisites>
-		</value>
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="TableSculpting" or defName="SimpleResearchBench"]/researchPrerequisites</xpath>
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="TableSculpting" or defName="SimpleResearchBench"]/researchPrerequisites</xpath>
+			<value>
+				<li>DankPyon_RusticFurniture</li>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="TableSculpting" or defName="SimpleResearchBench"]</xpath>
+			<value>
+				<researchPrerequisites>
+					<li>DankPyon_RusticFurniture</li>
+				</researchPrerequisites>
+			</value>
+		</nomatch>
 	</Operation>
 
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="SimpleResearchBench"]</xpath>
-		<value>
-			<researchPrerequisites>
-				<li>DankPyon_RusticFurniture</li>
-			</researchPrerequisites>
-		</value>
+	<Operation Class="PatchOperationConditional">
+		<xpath>Defs/ThingDef[defName="TableSculpting" or defName="FueledStove" or defName="TableButcher"]/researchPrerequisites</xpath>
+		<match Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="TableSculpting" or defName="FueledStove" or defName="TableButcher"]/researchPrerequisites</xpath>
+			<value>
+				<li>ComplexFurniture</li>
+			</value>
+		</match>
+		<nomatch Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName="TableSculpting" or defName="FueledStove" or defName="TableButcher"]</xpath>
+			<value>
+				<researchPrerequisites>
+					<li>ComplexFurniture</li>
+				</researchPrerequisites>
+			</value>
+		</nomatch>
 	</Operation>
-	
+
 	<!-- ============================ Core Research Project Coordinates ========================== -->
 	<Operation Class="PatchOperationFindMod">
 		<mods>

--- a/1.4/Patches/Vanilla Factions Expanded - Tribal/research.xml
+++ b/1.4/Patches/Vanilla Factions Expanded - Tribal/research.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Factions Expanded - Tribals</li>
+		</mods>
+
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- Hay/Straw processor -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="DankPyon_HayRack"]/researchPrerequisites</xpath>
+					<value>
+						<li>VFET_Agriculture</li>
+					</value>
+				</li>
+
+				<!-- Leather/Hide processor -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="DankPyon_DryRack" and not(researchPrerequisites)]</xpath>
+					<value>
+						<researchPrerequisites>
+							<li>VFET_Hunting</li>
+						</researchPrerequisites>
+					</value>
+				</li>
+
+				<!-- Butcher's Block -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="DankPyon_ButchersBlock" and not(researchPrerequisites)]</xpath>
+					<value>
+						<researchPrerequisites>
+							<li>VFET_Hunting</li>
+							<li>VFET_Construction</li>
+						</researchPrerequisites>
+					</value>
+				</li>
+
+				<!-- Mining Spot -->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="DankPyon_MiningSpot" and not(researchPrerequisites)]</xpath>
+					<value>
+						<researchPrerequisites>
+							<li>VFET_Mining</li>
+						</researchPrerequisites>
+					</value>
+				</li>
+
+				<!-- Butcher Table is complex -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[(
+							defName="TableButcher"
+						)]/researchPrerequisites</xpath>
+					<value>
+						<researchPrerequisites>
+							<li>DankPyon_RusticFurniture</li>
+						</researchPrerequisites>
+					</value>
+				</li>
+
+				<!-- Large Fire (wood logs) -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="VFET_LargeFire"]/costList</xpath>
+					<value>
+						<costList>
+							<DankPyon_RawWood>150</DankPyon_RawWood>
+						</costList>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>

--- a/About/About.xml
+++ b/About/About.xml
@@ -14,6 +14,7 @@
 		<li>LWM.DeepStorage</li>
 		<li>syrchalis.processor.framework</li>
 		<li>OskarPotocki.VanillaExpanded.RoyaltyPatches</li>
+		<li>OskarPotocki.VFE.Tribals</li>
 	</loadAfter>
 	<forceLoadAfter>
 		<li>OskarPotocki.VanillaExpanded.RoyaltyPatches</li>


### PR DESCRIPTION
Most of the important changes are in: 1.4/Patches/Change_Research.xml

VFET adds it's own patches to core research, so the previous patches were failing. This will add research prerequisites when the item has none while insert MO prerequisite when needed.

The Integrations patches for Research might be incomplete but not completely necessary, there are more mods that adds the needed research.